### PR TITLE
62-trading-signal-generation

### DIFF
--- a/src/day_trade/analysis/__init__.py
+++ b/src/day_trade/analysis/__init__.py
@@ -1,4 +1,13 @@
 # Technical analysis module
 from .indicators import TechnicalIndicators
+from .patterns import ChartPatternRecognizer
+from .signals import TradingSignalGenerator, SignalType, SignalStrength, TradingSignal
 
-__all__ = ['TechnicalIndicators']
+__all__ = [
+    'TechnicalIndicators',
+    'ChartPatternRecognizer',
+    'TradingSignalGenerator',
+    'SignalType',
+    'SignalStrength',
+    'TradingSignal'
+]

--- a/src/day_trade/analysis/patterns.py
+++ b/src/day_trade/analysis/patterns.py
@@ -1,0 +1,462 @@
+"""
+チャートパターン認識エンジン
+価格データからチャートパターンを認識する
+"""
+import logging
+from typing import Dict, List, Optional, Tuple
+import pandas as pd
+import numpy as np
+from scipy.signal import argrelextrema
+from sklearn.linear_model import LinearRegression
+
+logger = logging.getLogger(__name__)
+
+
+class ChartPatternRecognizer:
+    """チャートパターン認識クラス"""
+    
+    @staticmethod
+    def golden_dead_cross(
+        df: pd.DataFrame,
+        fast_period: int = 5,
+        slow_period: int = 20,
+        column: str = 'Close'
+    ) -> pd.DataFrame:
+        """
+        ゴールデンクロス・デッドクロスの検出
+        
+        Args:
+            df: 価格データのDataFrame
+            fast_period: 短期移動平均の期間
+            slow_period: 長期移動平均の期間
+            column: 計算対象の列名
+            
+        Returns:
+            クロスポイントを含むDataFrame
+        """
+        try:
+            # 移動平均を計算
+            fast_ma = df[column].rolling(window=fast_period).mean()
+            slow_ma = df[column].rolling(window=slow_period).mean()
+            
+            # クロスポイントを検出
+            fast_above = fast_ma > slow_ma
+            fast_above_shifted = fast_above.shift(1).fillna(False)
+            golden_cross = (fast_above & ~fast_above_shifted)
+            dead_cross = (~fast_above & fast_above_shifted)
+            
+            # 信頼度スコアを計算（クロス角度に基づく）
+            ma_diff = fast_ma - slow_ma
+            ma_diff_change = ma_diff.diff()
+            
+            golden_confidence = golden_cross * (ma_diff_change.abs() / df[column] * 100)
+            dead_confidence = dead_cross * (ma_diff_change.abs() / df[column] * 100)
+            
+            return pd.DataFrame({
+                f'Fast_MA_{fast_period}': fast_ma,
+                f'Slow_MA_{slow_period}': slow_ma,
+                'Golden_Cross': golden_cross,
+                'Dead_Cross': dead_cross,
+                'Golden_Confidence': golden_confidence.clip(0, 100),
+                'Dead_Confidence': dead_confidence.clip(0, 100)
+            })
+            
+        except Exception as e:
+            logger.error(f"ゴールデン・デッドクロス検出エラー: {e}")
+            return pd.DataFrame()
+    
+    @staticmethod
+    def support_resistance_levels(
+        df: pd.DataFrame,
+        window: int = 20,
+        num_levels: int = 3,
+        column: str = 'Close'
+    ) -> Dict[str, List[float]]:
+        """
+        サポート・レジスタンスラインの検出
+        
+        Args:
+            df: 価格データのDataFrame
+            window: 極値検出のウィンドウサイズ
+            num_levels: 検出するレベル数
+            column: 計算対象の列名
+            
+        Returns:
+            サポート・レジスタンスレベルの辞書
+        """
+        try:
+            prices = df[column].values
+            
+            # 極大値と極小値を検出
+            max_idx = argrelextrema(prices, np.greater, order=window)[0]
+            min_idx = argrelextrema(prices, np.less, order=window)[0]
+            
+            # 極値の価格を取得
+            resistance_candidates = prices[max_idx] if len(max_idx) > 0 else []
+            support_candidates = prices[min_idx] if len(min_idx) > 0 else []
+            
+            # クラスタリングして主要なレベルを特定
+            def cluster_levels(levels, num_clusters):
+                if len(levels) == 0:
+                    return []
+                
+                levels = np.array(levels)
+                clustered = []
+                
+                # K-meansの簡易版
+                sorted_levels = np.sort(levels)
+                if len(sorted_levels) <= num_clusters:
+                    return sorted_levels.tolist()
+                
+                # 等間隔でクラスタ中心を初期化
+                indices = np.linspace(0, len(sorted_levels) - 1, num_clusters, dtype=int)
+                centers = sorted_levels[indices]
+                
+                # 各レベルを最も近いクラスタに割り当て
+                for _ in range(10):  # 最大10回反復
+                    clusters = [[] for _ in range(num_clusters)]
+                    
+                    for level in sorted_levels:
+                        distances = np.abs(centers - level)
+                        nearest = np.argmin(distances)
+                        clusters[nearest].append(level)
+                    
+                    # クラスタ中心を更新
+                    new_centers = []
+                    for cluster in clusters:
+                        if cluster:
+                            new_centers.append(np.mean(cluster))
+                    
+                    if len(new_centers) == num_clusters:
+                        centers = np.array(new_centers)
+                
+                return sorted(centers.tolist(), reverse=True)
+            
+            resistance_levels = cluster_levels(resistance_candidates, num_levels)
+            support_levels = cluster_levels(support_candidates, num_levels)
+            
+            return {
+                'resistance': resistance_levels,
+                'support': sorted(support_levels)
+            }
+            
+        except Exception as e:
+            logger.error(f"サポート・レジスタンス検出エラー: {e}")
+            return {'resistance': [], 'support': []}
+    
+    @staticmethod
+    def breakout_detection(
+        df: pd.DataFrame,
+        lookback: int = 20,
+        threshold: float = 0.02,
+        volume_factor: float = 1.5
+    ) -> pd.DataFrame:
+        """
+        ブレイクアウトパターンの検出
+        
+        Args:
+            df: 価格データのDataFrame（Close, Volume列が必要）
+            lookback: 過去を見る期間
+            threshold: ブレイクアウト閾値（%）
+            volume_factor: ボリューム増加係数
+            
+        Returns:
+            ブレイクアウトシグナルを含むDataFrame
+        """
+        try:
+            # ローリング最高値・最安値
+            rolling_high = df['High'].rolling(window=lookback).max()
+            rolling_low = df['Low'].rolling(window=lookback).min()
+            
+            # ボリューム移動平均
+            volume_ma = df['Volume'].rolling(window=lookback).mean()
+            
+            # 上方ブレイクアウト
+            upward_breakout = (
+                (df['Close'] > rolling_high.shift(1)) &
+                (df['Volume'] > volume_ma * volume_factor)
+            )
+            
+            # 下方ブレイクアウト
+            downward_breakout = (
+                (df['Close'] < rolling_low.shift(1)) &
+                (df['Volume'] > volume_ma * volume_factor)
+            )
+            
+            # ブレイクアウトの強度を計算
+            upward_strength = np.where(
+                upward_breakout,
+                ((df['Close'] - rolling_high.shift(1)) / rolling_high.shift(1)) * 100,
+                0
+            )
+            
+            downward_strength = np.where(
+                downward_breakout,
+                ((rolling_low.shift(1) - df['Close']) / rolling_low.shift(1)) * 100,
+                0
+            )
+            
+            # 信頼度スコア（ブレイクアウトの強度とボリューム増加率に基づく）
+            volume_increase = df['Volume'] / volume_ma - 1
+            
+            upward_confidence = np.where(
+                upward_breakout,
+                np.minimum(
+                    (upward_strength * 10) * (1 + volume_increase.clip(0, 2)),
+                    100
+                ),
+                0
+            )
+            
+            downward_confidence = np.where(
+                downward_breakout,
+                np.minimum(
+                    (downward_strength * 10) * (1 + volume_increase.clip(0, 2)),
+                    100
+                ),
+                0
+            )
+            
+            return pd.DataFrame({
+                'Rolling_High': rolling_high,
+                'Rolling_Low': rolling_low,
+                'Upward_Breakout': upward_breakout,
+                'Downward_Breakout': downward_breakout,
+                'Upward_Strength': upward_strength,
+                'Downward_Strength': downward_strength,
+                'Upward_Confidence': upward_confidence,
+                'Downward_Confidence': downward_confidence
+            })
+            
+        except Exception as e:
+            logger.error(f"ブレイクアウト検出エラー: {e}")
+            return pd.DataFrame()
+    
+    @staticmethod
+    def trend_line_detection(
+        df: pd.DataFrame,
+        window: int = 20,
+        min_touches: int = 3
+    ) -> Dict[str, Dict[str, float]]:
+        """
+        トレンドラインの検出
+        
+        Args:
+            df: 価格データのDataFrame
+            window: 極値検出のウィンドウサイズ
+            min_touches: 最小接触回数
+            
+        Returns:
+            トレンドライン情報の辞書
+        """
+        try:
+            prices_high = df['High'].values
+            prices_low = df['Low'].values
+            
+            # 極大値と極小値を検出
+            max_idx = argrelextrema(prices_high, np.greater, order=window)[0]
+            min_idx = argrelextrema(prices_low, np.less, order=window)[0]
+            
+            result = {}
+            
+            # 上昇トレンドライン（極小値を結ぶ）
+            if len(min_idx) >= min_touches:
+                X = min_idx.reshape(-1, 1)
+                y = prices_low[min_idx]
+                
+                model = LinearRegression()
+                model.fit(X, y)
+                
+                slope = model.coef_[0]
+                intercept = model.intercept_
+                r2 = model.score(X, y)
+                
+                # 最新のトレンドライン値
+                current_value = slope * len(df) + intercept
+                
+                result['support_trend'] = {
+                    'slope': slope,
+                    'intercept': intercept,
+                    'r2': r2,
+                    'current_value': current_value,
+                    'touches': len(min_idx),
+                    'angle': np.degrees(np.arctan(slope / np.mean(prices_low))) 
+                }
+            
+            # 下降トレンドライン（極大値を結ぶ）
+            if len(max_idx) >= min_touches:
+                X = max_idx.reshape(-1, 1)
+                y = prices_high[max_idx]
+                
+                model = LinearRegression()
+                model.fit(X, y)
+                
+                slope = model.coef_[0]
+                intercept = model.intercept_
+                r2 = model.score(X, y)
+                
+                # 最新のトレンドライン値
+                current_value = slope * len(df) + intercept
+                
+                result['resistance_trend'] = {
+                    'slope': slope,
+                    'intercept': intercept,
+                    'r2': r2,
+                    'current_value': current_value,
+                    'touches': len(max_idx),
+                    'angle': np.degrees(np.arctan(slope / np.mean(prices_high)))
+                }
+            
+            return result
+            
+        except Exception as e:
+            logger.error(f"トレンドライン検出エラー: {e}")
+            return {}
+    
+    @staticmethod
+    def detect_all_patterns(
+        df: pd.DataFrame,
+        golden_cross_fast: int = 5,
+        golden_cross_slow: int = 20,
+        support_resistance_window: int = 20,
+        breakout_lookback: int = 20,
+        trend_window: int = 20
+    ) -> Dict[str, any]:
+        """
+        全パターンを検出
+        
+        Args:
+            df: 価格データのDataFrame
+            各種パラメータ
+            
+        Returns:
+            全パターン検出結果の辞書
+        """
+        try:
+            results = {}
+            
+            # ゴールデン・デッドクロス
+            cross_data = ChartPatternRecognizer.golden_dead_cross(
+                df, golden_cross_fast, golden_cross_slow
+            )
+            results['crosses'] = cross_data
+            
+            # 最新のクロスシグナル
+            if len(cross_data) > 0:
+                latest_idx = -1
+                if cross_data['Golden_Cross'].iloc[latest_idx]:
+                    results['latest_signal'] = {
+                        'type': 'Golden Cross',
+                        'confidence': cross_data['Golden_Confidence'].iloc[latest_idx]
+                    }
+                elif cross_data['Dead_Cross'].iloc[latest_idx]:
+                    results['latest_signal'] = {
+                        'type': 'Dead Cross',
+                        'confidence': cross_data['Dead_Confidence'].iloc[latest_idx]
+                    }
+            
+            # サポート・レジスタンス
+            levels = ChartPatternRecognizer.support_resistance_levels(
+                df, support_resistance_window
+            )
+            results['levels'] = levels
+            
+            # ブレイクアウト
+            breakout_data = ChartPatternRecognizer.breakout_detection(
+                df, breakout_lookback
+            )
+            results['breakouts'] = breakout_data
+            
+            # トレンドライン
+            trends = ChartPatternRecognizer.trend_line_detection(
+                df, trend_window
+            )
+            results['trends'] = trends
+            
+            # 総合スコア（各パターンの信頼度を統合）
+            confidence_scores = []
+            
+            # クロスシグナルの信頼度
+            if 'latest_signal' in results:
+                confidence_scores.append(results['latest_signal']['confidence'])
+            
+            # ブレイクアウトの信頼度
+            if len(breakout_data) > 0:
+                latest_up = breakout_data['Upward_Confidence'].iloc[-1]
+                latest_down = breakout_data['Downward_Confidence'].iloc[-1]
+                if latest_up > 0:
+                    confidence_scores.append(latest_up)
+                if latest_down > 0:
+                    confidence_scores.append(latest_down)
+            
+            # トレンドの信頼度（R²値を使用）
+            for trend_type, trend_info in trends.items():
+                if 'r2' in trend_info:
+                    confidence_scores.append(trend_info['r2'] * 100)
+            
+            if confidence_scores:
+                results['overall_confidence'] = np.mean(confidence_scores)
+            else:
+                results['overall_confidence'] = 0
+            
+            return results
+            
+        except Exception as e:
+            logger.error(f"全パターン検出エラー: {e}")
+            return {}
+
+
+# 使用例
+if __name__ == "__main__":
+    import numpy as np
+    from datetime import datetime, timedelta
+    
+    # サンプルデータ作成
+    dates = pd.date_range(end=datetime.now(), periods=100, freq='D')
+    np.random.seed(42)
+    
+    # トレンドのあるデータを生成
+    trend = np.linspace(100, 120, 100)
+    noise = np.random.randn(100) * 2
+    close_prices = trend + noise
+    
+    df = pd.DataFrame({
+        'Date': dates,
+        'Open': close_prices + np.random.randn(100) * 0.5,
+        'High': close_prices + np.abs(np.random.randn(100)) * 2,
+        'Low': close_prices - np.abs(np.random.randn(100)) * 2,
+        'Close': close_prices,
+        'Volume': np.random.randint(1000000, 5000000, 100)
+    })
+    df.set_index('Date', inplace=True)
+    
+    # パターン認識
+    recognizer = ChartPatternRecognizer()
+    
+    print("=== ゴールデン・デッドクロス ===")
+    crosses = recognizer.golden_dead_cross(df)
+    golden_dates = df.index[crosses['Golden_Cross']]
+    dead_dates = df.index[crosses['Dead_Cross']]
+    
+    print(f"ゴールデンクロス: {len(golden_dates)}回")
+    for date in golden_dates:
+        confidence = crosses.loc[date, 'Golden_Confidence']
+        print(f"  {date.date()}: 信頼度 {confidence:.1f}%")
+    
+    print(f"\nデッドクロス: {len(dead_dates)}回")
+    for date in dead_dates:
+        confidence = crosses.loc[date, 'Dead_Confidence']
+        print(f"  {date.date()}: 信頼度 {confidence:.1f}%")
+    
+    print("\n=== サポート・レジスタンス ===")
+    levels = recognizer.support_resistance_levels(df)
+    print(f"レジスタンス: {[f'{level:.2f}' for level in levels['resistance']]}")
+    print(f"サポート: {[f'{level:.2f}' for level in levels['support']]}")
+    
+    print("\n=== 全パターン検出 ===")
+    all_patterns = recognizer.detect_all_patterns(df)
+    print(f"総合信頼度: {all_patterns['overall_confidence']:.1f}%")
+    
+    if 'latest_signal' in all_patterns:
+        signal = all_patterns['latest_signal']
+        print(f"最新シグナル: {signal['type']} (信頼度: {signal['confidence']:.1f}%)")

--- a/src/day_trade/analysis/signals.py
+++ b/src/day_trade/analysis/signals.py
@@ -1,0 +1,638 @@
+"""
+売買シグナル生成エンジン
+テクニカル指標とチャートパターンを組み合わせてシグナルを生成する
+"""
+import logging
+from typing import Dict, List, Optional, Tuple, Union
+from enum import Enum
+import pandas as pd
+import numpy as np
+from dataclasses import dataclass
+
+from .indicators import TechnicalIndicators
+from .patterns import ChartPatternRecognizer
+
+logger = logging.getLogger(__name__)
+
+
+class SignalType(Enum):
+    """シグナルタイプ"""
+    BUY = "buy"
+    SELL = "sell"
+    HOLD = "hold"
+
+
+class SignalStrength(Enum):
+    """シグナル強度"""
+    STRONG = "strong"
+    MEDIUM = "medium"
+    WEAK = "weak"
+
+
+@dataclass
+class TradingSignal:
+    """売買シグナル情報"""
+    signal_type: SignalType
+    strength: SignalStrength
+    confidence: float  # 0-100
+    reasons: List[str]
+    conditions_met: Dict[str, bool]
+    timestamp: pd.Timestamp
+    price: float
+
+
+class SignalRule:
+    """シグナルルールの基底クラス"""
+    
+    def __init__(self, name: str, weight: float = 1.0):
+        self.name = name
+        self.weight = weight
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        """
+        ルールを評価
+        
+        Returns:
+            条件が満たされたか、信頼度スコア
+        """
+        raise NotImplementedError
+
+
+class RSIOversoldRule(SignalRule):
+    """RSI過売りルール"""
+    
+    def __init__(self, threshold: float = 30, weight: float = 1.0):
+        super().__init__("RSI Oversold", weight)
+        self.threshold = threshold
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'RSI' not in indicators.columns:
+            return False, 0.0
+        
+        latest_rsi = indicators['RSI'].iloc[-1]
+        if pd.isna(latest_rsi):
+            return False, 0.0
+        
+        if latest_rsi < self.threshold:
+            # RSIが低いほど信頼度が高い
+            confidence = (self.threshold - latest_rsi) / self.threshold * 100
+            return True, min(confidence * 2, 100)
+        
+        return False, 0.0
+
+
+class RSIOverboughtRule(SignalRule):
+    """RSI過買いルール"""
+    
+    def __init__(self, threshold: float = 70, weight: float = 1.0):
+        super().__init__("RSI Overbought", weight)
+        self.threshold = threshold
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'RSI' not in indicators.columns:
+            return False, 0.0
+        
+        latest_rsi = indicators['RSI'].iloc[-1]
+        if pd.isna(latest_rsi):
+            return False, 0.0
+        
+        if latest_rsi > self.threshold:
+            # RSIが高いほど信頼度が高い
+            confidence = (latest_rsi - self.threshold) / (100 - self.threshold) * 100
+            return True, min(confidence * 2, 100)
+        
+        return False, 0.0
+
+
+class MACDCrossoverRule(SignalRule):
+    """MACDクロスオーバールール"""
+    
+    def __init__(self, lookback: int = 2, weight: float = 1.5):
+        super().__init__("MACD Crossover", weight)
+        self.lookback = lookback
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'MACD' not in indicators.columns or 'MACD_Signal' not in indicators.columns:
+            return False, 0.0
+        
+        macd = indicators['MACD'].iloc[-self.lookback:]
+        signal = indicators['MACD_Signal'].iloc[-self.lookback:]
+        
+        if len(macd) < self.lookback or macd.isna().any() or signal.isna().any():
+            return False, 0.0
+        
+        # ゴールデンクロスをチェック
+        crossed_above = (macd.iloc[-2] <= signal.iloc[-2]) and (macd.iloc[-1] > signal.iloc[-1])
+        
+        if crossed_above:
+            # クロスの角度から信頼度を計算
+            angle = abs(macd.iloc[-1] - signal.iloc[-1]) / df['Close'].iloc[-1] * 100
+            confidence = min(angle * 20, 100)
+            return True, confidence
+        
+        return False, 0.0
+
+
+class MACDDeathCrossRule(SignalRule):
+    """MACDデスクロスルール"""
+    
+    def __init__(self, lookback: int = 2, weight: float = 1.5):
+        super().__init__("MACD Death Cross", weight)
+        self.lookback = lookback
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'MACD' not in indicators.columns or 'MACD_Signal' not in indicators.columns:
+            return False, 0.0
+        
+        macd = indicators['MACD'].iloc[-self.lookback:]
+        signal = indicators['MACD_Signal'].iloc[-self.lookback:]
+        
+        if len(macd) < self.lookback or macd.isna().any() or signal.isna().any():
+            return False, 0.0
+        
+        # デスクロスをチェック
+        crossed_below = (macd.iloc[-2] >= signal.iloc[-2]) and (macd.iloc[-1] < signal.iloc[-1])
+        
+        if crossed_below:
+            # クロスの角度から信頼度を計算
+            angle = abs(signal.iloc[-1] - macd.iloc[-1]) / df['Close'].iloc[-1] * 100
+            confidence = min(angle * 20, 100)
+            return True, confidence
+        
+        return False, 0.0
+
+
+class BollingerBandRule(SignalRule):
+    """ボリンジャーバンドルール"""
+    
+    def __init__(self, position: str = "lower", weight: float = 1.0):
+        """
+        Args:
+            position: "lower" (買いシグナル) or "upper" (売りシグナル)
+        """
+        super().__init__(f"Bollinger Band {position}", weight)
+        self.position = position
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'BB_Upper' not in indicators.columns or 'BB_Lower' not in indicators.columns:
+            return False, 0.0
+        
+        close_price = df['Close'].iloc[-1]
+        
+        if self.position == "lower":
+            bb_lower = indicators['BB_Lower'].iloc[-1]
+            if pd.isna(bb_lower):
+                return False, 0.0
+            
+            if close_price <= bb_lower:
+                # バンドからの乖離率を信頼度に
+                deviation = (bb_lower - close_price) / close_price * 100
+                confidence = min(deviation * 10, 100)
+                return True, confidence
+        
+        elif self.position == "upper":
+            bb_upper = indicators['BB_Upper'].iloc[-1]
+            if pd.isna(bb_upper):
+                return False, 0.0
+            
+            if close_price >= bb_upper:
+                # バンドからの乖離率を信頼度に
+                deviation = (close_price - bb_upper) / close_price * 100
+                confidence = min(deviation * 10, 100)
+                return True, confidence
+        
+        return False, 0.0
+
+
+class PatternBreakoutRule(SignalRule):
+    """パターンブレイクアウトルール"""
+    
+    def __init__(self, direction: str = "upward", weight: float = 2.0):
+        """
+        Args:
+            direction: "upward" or "downward"
+        """
+        super().__init__(f"{direction.capitalize()} Breakout", weight)
+        self.direction = direction
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'breakouts' not in patterns or len(patterns['breakouts']) == 0:
+            return False, 0.0
+        
+        breakouts = patterns['breakouts']
+        
+        if self.direction == "upward":
+            if 'Upward_Breakout' in breakouts.columns:
+                latest_breakout = breakouts['Upward_Breakout'].iloc[-1]
+                confidence = breakouts['Upward_Confidence'].iloc[-1]
+                
+                if latest_breakout and confidence > 0:
+                    return True, confidence
+        
+        elif self.direction == "downward":
+            if 'Downward_Breakout' in breakouts.columns:
+                latest_breakout = breakouts['Downward_Breakout'].iloc[-1]
+                confidence = breakouts['Downward_Confidence'].iloc[-1]
+                
+                if latest_breakout and confidence > 0:
+                    return True, confidence
+        
+        return False, 0.0
+
+
+class GoldenCrossRule(SignalRule):
+    """ゴールデンクロスルール"""
+    
+    def __init__(self, weight: float = 2.0):
+        super().__init__("Golden Cross", weight)
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'crosses' not in patterns or len(patterns['crosses']) == 0:
+            return False, 0.0
+        
+        crosses = patterns['crosses']
+        
+        if 'Golden_Cross' in crosses.columns:
+            # 最新とその前をチェック（直近でクロスが発生したか）
+            recent_crosses = crosses['Golden_Cross'].iloc[-3:]
+            if recent_crosses.any():
+                # 最も新しいクロスの信頼度を取得
+                idx = recent_crosses[recent_crosses].index[-1]
+                confidence = crosses.loc[idx, 'Golden_Confidence']
+                return True, confidence
+        
+        return False, 0.0
+
+
+class DeadCrossRule(SignalRule):
+    """デッドクロスルール"""
+    
+    def __init__(self, weight: float = 2.0):
+        super().__init__("Dead Cross", weight)
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if 'crosses' not in patterns or len(patterns['crosses']) == 0:
+            return False, 0.0
+        
+        crosses = patterns['crosses']
+        
+        if 'Dead_Cross' in crosses.columns:
+            # 最新とその前をチェック（直近でクロスが発生したか）
+            recent_crosses = crosses['Dead_Cross'].iloc[-3:]
+            if recent_crosses.any():
+                # 最も新しいクロスの信頼度を取得
+                idx = recent_crosses[recent_crosses].index[-1]
+                confidence = crosses.loc[idx, 'Dead_Confidence']
+                return True, confidence
+        
+        return False, 0.0
+
+
+class TradingSignalGenerator:
+    """売買シグナル生成クラス"""
+    
+    def __init__(self):
+        """デフォルトルールセットで初期化"""
+        self.buy_rules: List[SignalRule] = [
+            RSIOversoldRule(threshold=30, weight=1.0),
+            MACDCrossoverRule(weight=1.5),
+            BollingerBandRule(position="lower", weight=1.0),
+            PatternBreakoutRule(direction="upward", weight=2.0),
+            GoldenCrossRule(weight=2.0)
+        ]
+        
+        self.sell_rules: List[SignalRule] = [
+            RSIOverboughtRule(threshold=70, weight=1.0),
+            MACDDeathCrossRule(weight=1.5),
+            BollingerBandRule(position="upper", weight=1.0),
+            PatternBreakoutRule(direction="downward", weight=2.0),
+            DeadCrossRule(weight=2.0)
+        ]
+    
+    def add_buy_rule(self, rule: SignalRule):
+        """買いルールを追加"""
+        self.buy_rules.append(rule)
+    
+    def add_sell_rule(self, rule: SignalRule):
+        """売りルールを追加"""
+        self.sell_rules.append(rule)
+    
+    def clear_rules(self):
+        """すべてのルールをクリア"""
+        self.buy_rules.clear()
+        self.sell_rules.clear()
+    
+    def generate_signal(
+        self,
+        df: pd.DataFrame,
+        indicators: Optional[pd.DataFrame] = None,
+        patterns: Optional[Dict] = None
+    ) -> Optional[TradingSignal]:
+        """
+        売買シグナルを生成
+        
+        Args:
+            df: 価格データのDataFrame
+            indicators: テクニカル指標のDataFrame
+            patterns: チャートパターン認識結果
+            
+        Returns:
+            TradingSignal or None
+        """
+        try:
+            # データの検証
+            if df.empty or len(df) < 20:
+                logger.warning("データが不足しています")
+                return None
+            
+            # 指標を計算（提供されていない場合）
+            if indicators is None:
+                indicators = TechnicalIndicators.calculate_all(df)
+            
+            # パターンを認識（提供されていない場合）
+            if patterns is None:
+                patterns = ChartPatternRecognizer.detect_all_patterns(df)
+            
+            # 買いシグナルの評価
+            buy_conditions = {}
+            buy_confidences = []
+            buy_reasons = []
+            total_buy_weight = 0
+            
+            for rule in self.buy_rules:
+                met, confidence = rule.evaluate(df, indicators, patterns)
+                buy_conditions[rule.name] = met
+                
+                if met:
+                    weighted_confidence = confidence * rule.weight
+                    buy_confidences.append(weighted_confidence)
+                    buy_reasons.append(f"{rule.name} (信頼度: {confidence:.0f}%)")
+                    total_buy_weight += rule.weight
+            
+            # 売りシグナルの評価
+            sell_conditions = {}
+            sell_confidences = []
+            sell_reasons = []
+            total_sell_weight = 0
+            
+            for rule in self.sell_rules:
+                met, confidence = rule.evaluate(df, indicators, patterns)
+                sell_conditions[rule.name] = met
+                
+                if met:
+                    weighted_confidence = confidence * rule.weight
+                    sell_confidences.append(weighted_confidence)
+                    sell_reasons.append(f"{rule.name} (信頼度: {confidence:.0f}%)")
+                    total_sell_weight += rule.weight
+            
+            # シグナルの決定
+            buy_score = sum(buy_confidences) / total_buy_weight if total_buy_weight > 0 else 0
+            sell_score = sum(sell_confidences) / total_sell_weight if total_sell_weight > 0 else 0
+            
+            # 最新の価格とタイムスタンプ
+            latest_price = df['Close'].iloc[-1]
+            latest_timestamp = df.index[-1]
+            
+            # シグナルタイプと強度の決定
+            if buy_score > sell_score and buy_score > 0:
+                # 買いシグナル
+                signal_type = SignalType.BUY
+                confidence = buy_score
+                reasons = buy_reasons
+                conditions_met = {**buy_conditions, **sell_conditions}
+                
+                # 強度の判定
+                active_rules = sum(1 for v in buy_conditions.values() if v)
+                if confidence >= 70 and active_rules >= 3:
+                    strength = SignalStrength.STRONG
+                elif confidence >= 40 and active_rules >= 2:
+                    strength = SignalStrength.MEDIUM
+                else:
+                    strength = SignalStrength.WEAK
+            
+            elif sell_score > buy_score and sell_score > 0:
+                # 売りシグナル
+                signal_type = SignalType.SELL
+                confidence = sell_score
+                reasons = sell_reasons
+                conditions_met = {**buy_conditions, **sell_conditions}
+                
+                # 強度の判定
+                active_rules = sum(1 for v in sell_conditions.values() if v)
+                if confidence >= 70 and active_rules >= 3:
+                    strength = SignalStrength.STRONG
+                elif confidence >= 40 and active_rules >= 2:
+                    strength = SignalStrength.MEDIUM
+                else:
+                    strength = SignalStrength.WEAK
+            
+            else:
+                # ホールド
+                signal_type = SignalType.HOLD
+                confidence = 0
+                strength = SignalStrength.WEAK
+                reasons = ["明確なシグナルなし"]
+                conditions_met = {**buy_conditions, **sell_conditions}
+            
+            return TradingSignal(
+                signal_type=signal_type,
+                strength=strength,
+                confidence=confidence,
+                reasons=reasons,
+                conditions_met=conditions_met,
+                timestamp=latest_timestamp,
+                price=latest_price
+            )
+            
+        except Exception as e:
+            logger.error(f"シグナル生成エラー: {e}")
+            return None
+    
+    def generate_signals_series(
+        self,
+        df: pd.DataFrame,
+        lookback_window: int = 50
+    ) -> pd.DataFrame:
+        """
+        時系列でシグナルを生成
+        
+        Args:
+            df: 価格データのDataFrame
+            lookback_window: 各時点での計算に使用する過去データ数
+            
+        Returns:
+            シグナル情報を含むDataFrame
+        """
+        try:
+            signals = []
+            
+            # 最低限必要なデータ数
+            min_required = max(lookback_window, 50)
+            
+            for i in range(min_required, len(df)):
+                # ウィンドウ内のデータを取得
+                window_df = df.iloc[i-lookback_window:i+1].copy()
+                
+                # シグナルを生成
+                signal = self.generate_signal(window_df)
+                
+                if signal:
+                    signals.append({
+                        'Date': signal.timestamp,
+                        'Signal': signal.signal_type.value,
+                        'Strength': signal.strength.value,
+                        'Confidence': signal.confidence,
+                        'Price': signal.price,
+                        'Reasons': ', '.join(signal.reasons)
+                    })
+            
+            if signals:
+                signals_df = pd.DataFrame(signals)
+                signals_df.set_index('Date', inplace=True)
+                return signals_df
+            else:
+                return pd.DataFrame()
+                
+        except Exception as e:
+            logger.error(f"時系列シグナル生成エラー: {e}")
+            return pd.DataFrame()
+    
+    def validate_signal(
+        self,
+        signal: TradingSignal,
+        historical_performance: Optional[pd.DataFrame] = None
+    ) -> float:
+        """
+        シグナルの有効性を検証
+        
+        Args:
+            signal: 検証するシグナル
+            historical_performance: 過去のパフォーマンスデータ
+            
+        Returns:
+            有効性スコア（0-100）
+        """
+        try:
+            base_score = signal.confidence
+            
+            # 強度による調整
+            if signal.strength == SignalStrength.STRONG:
+                base_score *= 1.2
+            elif signal.strength == SignalStrength.WEAK:
+                base_score *= 0.8
+            
+            # 複数条件の組み合わせによるボーナス
+            active_conditions = sum(1 for v in signal.conditions_met.values() if v)
+            if active_conditions >= 3:
+                base_score *= 1.1
+            
+            # 過去のパフォーマンスがある場合は参考にする
+            if historical_performance is not None and len(historical_performance) > 0:
+                # 同じタイプのシグナルの成功率を計算
+                same_type = historical_performance[
+                    historical_performance['Signal'] == signal.signal_type.value
+                ]
+                
+                if len(same_type) > 0:
+                    # 仮の成功率（実際の取引結果が必要）
+                    # ここでは簡単のため、強度が高いほど成功率が高いと仮定
+                    success_rate = same_type[same_type['Strength'] == 'strong'].shape[0] / len(same_type)
+                    base_score *= (0.7 + 0.3 * success_rate)
+            
+            return min(base_score, 100)
+            
+        except Exception as e:
+            logger.error(f"シグナル検証エラー: {e}")
+            return 0.0
+
+
+# カスタムルールの例
+class VolumeSpikeBuyRule(SignalRule):
+    """出来高急増買いルール"""
+    
+    def __init__(self, volume_factor: float = 2.0, price_change: float = 0.02, weight: float = 1.5):
+        super().__init__("Volume Spike Buy", weight)
+        self.volume_factor = volume_factor
+        self.price_change = price_change
+    
+    def evaluate(self, df: pd.DataFrame, indicators: pd.DataFrame, patterns: Dict) -> Tuple[bool, float]:
+        if len(df) < 20:
+            return False, 0.0
+        
+        # 平均出来高
+        avg_volume = df['Volume'].iloc[-20:-1].mean()
+        latest_volume = df['Volume'].iloc[-1]
+        
+        # 価格変化
+        price_change = (df['Close'].iloc[-1] - df['Close'].iloc[-2]) / df['Close'].iloc[-2]
+        
+        # 出来高が平均の2倍以上かつ価格が2%以上上昇
+        if latest_volume > avg_volume * self.volume_factor and price_change > self.price_change:
+            volume_ratio = latest_volume / avg_volume
+            confidence = min((volume_ratio - self.volume_factor) * 20 + 50, 100)
+            return True, confidence
+        
+        return False, 0.0
+
+
+# 使用例
+if __name__ == "__main__":
+    import numpy as np
+    from datetime import datetime, timedelta
+    
+    # サンプルデータ作成
+    dates = pd.date_range(end=datetime.now(), periods=100, freq='D')
+    np.random.seed(42)
+    
+    # トレンドのあるデータを生成
+    trend = np.linspace(100, 120, 100)
+    noise = np.random.randn(100) * 2
+    close_prices = trend + noise
+    
+    df = pd.DataFrame({
+        'Date': dates,
+        'Open': close_prices + np.random.randn(100) * 0.5,
+        'High': close_prices + np.abs(np.random.randn(100)) * 2,
+        'Low': close_prices - np.abs(np.random.randn(100)) * 2,
+        'Close': close_prices,
+        'Volume': np.random.randint(1000000, 5000000, 100)
+    })
+    df.set_index('Date', inplace=True)
+    
+    # シグナル生成
+    generator = TradingSignalGenerator()
+    
+    # カスタムルールを追加
+    generator.add_buy_rule(VolumeSpikeBuyRule())
+    
+    # 最新のシグナルを生成
+    signal = generator.generate_signal(df)
+    
+    if signal:
+        print(f"シグナル: {signal.signal_type.value.upper()}")
+        print(f"強度: {signal.strength.value}")
+        print(f"信頼度: {signal.confidence:.1f}%")
+        print(f"価格: {signal.price:.2f}")
+        print("\n理由:")
+        for reason in signal.reasons:
+            print(f"  - {reason}")
+        
+        print("\n条件の状態:")
+        for condition, met in signal.conditions_met.items():
+            status = "✓" if met else "✗"
+            print(f"  {status} {condition}")
+        
+        # シグナルの検証
+        validity = generator.validate_signal(signal)
+        print(f"\n有効性スコア: {validity:.1f}%")
+    else:
+        print("シグナルなし")
+    
+    # 時系列シグナル生成
+    print("\n=== 時系列シグナル ===")
+    signals_series = generator.generate_signals_series(df, lookback_window=30)
+    
+    if not signals_series.empty:
+        # 買い/売りシグナルのみ表示
+        active_signals = signals_series[signals_series['Signal'] != 'hold']
+        print(active_signals.tail(10))

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,397 @@
+"""
+売買シグナル生成エンジンのテスト
+"""
+import pytest
+import pandas as pd
+import numpy as np
+from datetime import datetime, timedelta
+
+from src.day_trade.analysis.signals import (
+    TradingSignalGenerator, 
+    SignalType, 
+    SignalStrength,
+    TradingSignal,
+    SignalRule,
+    RSIOversoldRule,
+    RSIOverboughtRule,
+    MACDCrossoverRule,
+    MACDDeathCrossRule,
+    BollingerBandRule,
+    PatternBreakoutRule,
+    GoldenCrossRule,
+    DeadCrossRule,
+    VolumeSpikeBuyRule
+)
+from src.day_trade.analysis.indicators import TechnicalIndicators
+from src.day_trade.analysis.patterns import ChartPatternRecognizer
+
+
+class TestSignalRules:
+    """個別ルールのテスト"""
+    
+    @pytest.fixture
+    def sample_data(self):
+        """テスト用のサンプルデータ"""
+        dates = pd.date_range(end=datetime.now(), periods=100, freq='D')
+        np.random.seed(42)
+        
+        # トレンドのあるデータを生成
+        trend = np.linspace(100, 120, 100)
+        noise = np.random.randn(100) * 1
+        close_prices = trend + noise
+        
+        df = pd.DataFrame({
+            'Date': dates,
+            'Open': close_prices + np.random.randn(100) * 0.5,
+            'High': close_prices + np.abs(np.random.randn(100)) * 1.5,
+            'Low': close_prices - np.abs(np.random.randn(100)) * 1.5,
+            'Close': close_prices,
+            'Volume': np.random.randint(1000000, 5000000, 100)
+        })
+        df.set_index('Date', inplace=True)
+        
+        return df
+    
+    @pytest.fixture
+    def indicators_data(self, sample_data):
+        """計算済みのテクニカル指標"""
+        return TechnicalIndicators.calculate_all(sample_data)
+    
+    @pytest.fixture
+    def patterns_data(self, sample_data):
+        """認識済みのチャートパターン"""
+        return ChartPatternRecognizer.detect_all_patterns(sample_data)
+    
+    def test_rsi_oversold_rule(self, sample_data, indicators_data, patterns_data):
+        """RSI過売りルールのテスト"""
+        # RSIを人工的に低く設定
+        indicators_data.loc[indicators_data.index[-1], 'RSI'] = 25
+        
+        rule = RSIOversoldRule(threshold=30)
+        met, confidence = rule.evaluate(sample_data, indicators_data, patterns_data)
+        
+        assert met is True
+        assert confidence > 0
+        assert confidence <= 100
+    
+    def test_rsi_overbought_rule(self, sample_data, indicators_data, patterns_data):
+        """RSI過買いルールのテスト"""
+        # RSIを人工的に高く設定
+        indicators_data.loc[indicators_data.index[-1], 'RSI'] = 75
+        
+        rule = RSIOverboughtRule(threshold=70)
+        met, confidence = rule.evaluate(sample_data, indicators_data, patterns_data)
+        
+        assert met is True
+        assert confidence > 0
+        assert confidence <= 100
+    
+    def test_macd_crossover_rule(self, sample_data):
+        """MACDクロスオーバールールのテスト"""
+        # MACDクロスオーバーを人工的に作成
+        indicators = pd.DataFrame(index=sample_data.index)
+        indicators['MACD'] = [0] * (len(sample_data) - 2) + [-0.5, 0.5]
+        indicators['MACD_Signal'] = [0] * len(sample_data)
+        
+        rule = MACDCrossoverRule()
+        met, confidence = rule.evaluate(sample_data, indicators, {})
+        
+        assert met is True
+        assert confidence > 0
+    
+    def test_bollinger_band_lower_rule(self, sample_data):
+        """ボリンジャーバンド下限ルールのテスト"""
+        # 価格をバンド下限以下に設定
+        indicators = pd.DataFrame(index=sample_data.index)
+        indicators['BB_Lower'] = sample_data['Close'] + 2
+        indicators['BB_Upper'] = sample_data['Close'] + 5
+        
+        rule = BollingerBandRule(position="lower")
+        met, confidence = rule.evaluate(sample_data, indicators, {})
+        
+        assert met is True
+        assert confidence > 0
+    
+    def test_pattern_breakout_rule(self, sample_data, indicators_data):
+        """パターンブレイクアウトルールのテスト"""
+        # ブレイクアウトパターンを作成
+        breakouts = pd.DataFrame(index=sample_data.index)
+        breakouts['Upward_Breakout'] = [False] * (len(sample_data) - 1) + [True]
+        breakouts['Upward_Confidence'] = [0] * (len(sample_data) - 1) + [80]
+        
+        patterns = {'breakouts': breakouts}
+        
+        rule = PatternBreakoutRule(direction="upward")
+        met, confidence = rule.evaluate(sample_data, indicators_data, patterns)
+        
+        assert met is True
+        assert confidence == 80
+    
+    def test_golden_cross_rule(self, sample_data, indicators_data):
+        """ゴールデンクロスルールのテスト"""
+        # ゴールデンクロスを作成
+        crosses = pd.DataFrame(index=sample_data.index)
+        crosses['Golden_Cross'] = [False] * (len(sample_data) - 3) + [True, False, False]
+        crosses['Golden_Confidence'] = [0] * (len(sample_data) - 3) + [75, 0, 0]
+        
+        patterns = {'crosses': crosses}
+        
+        rule = GoldenCrossRule()
+        met, confidence = rule.evaluate(sample_data, indicators_data, patterns)
+        
+        assert met is True
+        assert confidence == 75
+    
+    def test_volume_spike_buy_rule(self, sample_data, indicators_data, patterns_data):
+        """出来高急増買いルールのテスト"""
+        # 出来高と価格を調整
+        sample_data.loc[sample_data.index[-1], 'Volume'] = 10000000
+        sample_data.loc[sample_data.index[-1], 'Close'] = sample_data['Close'].iloc[-2] * 1.03
+        
+        rule = VolumeSpikeBuyRule(volume_factor=2.0, price_change=0.02)
+        met, confidence = rule.evaluate(sample_data, indicators_data, patterns_data)
+        
+        assert met is True
+        assert confidence > 0
+
+
+class TestTradingSignalGenerator:
+    """売買シグナル生成クラスのテスト"""
+    
+    @pytest.fixture
+    def sample_data(self):
+        """テスト用のサンプルデータ"""
+        dates = pd.date_range(end=datetime.now(), periods=100, freq='D')
+        np.random.seed(42)
+        
+        # トレンドのあるデータを生成
+        trend = np.linspace(100, 120, 100)
+        noise = np.random.randn(100) * 1
+        close_prices = trend + noise
+        
+        df = pd.DataFrame({
+            'Date': dates,
+            'Open': close_prices + np.random.randn(100) * 0.5,
+            'High': close_prices + np.abs(np.random.randn(100)) * 1.5,
+            'Low': close_prices - np.abs(np.random.randn(100)) * 1.5,
+            'Close': close_prices,
+            'Volume': np.random.randint(1000000, 5000000, 100)
+        })
+        df.set_index('Date', inplace=True)
+        
+        return df
+    
+    @pytest.fixture
+    def generator(self):
+        """シグナル生成器のインスタンス"""
+        return TradingSignalGenerator()
+    
+    def test_generate_signal_basic(self, generator, sample_data):
+        """基本的なシグナル生成のテスト"""
+        signal = generator.generate_signal(sample_data)
+        
+        assert signal is not None
+        assert isinstance(signal, TradingSignal)
+        assert signal.signal_type in [SignalType.BUY, SignalType.SELL, SignalType.HOLD]
+        assert signal.strength in [SignalStrength.STRONG, SignalStrength.MEDIUM, SignalStrength.WEAK]
+        assert 0 <= signal.confidence <= 100
+        assert len(signal.reasons) > 0
+        assert isinstance(signal.conditions_met, dict)
+        assert signal.price > 0
+    
+    def test_generate_signal_buy(self, generator, sample_data):
+        """買いシグナル生成のテスト"""
+        # RSIを低く設定して買いシグナルを誘発
+        indicators = TechnicalIndicators.calculate_all(sample_data)
+        indicators.loc[indicators.index[-1], 'RSI'] = 25
+        
+        signal = generator.generate_signal(sample_data, indicators=indicators)
+        
+        assert signal is not None
+        # RSIが低いので買いシグナルが出やすい
+        if signal.signal_type == SignalType.BUY:
+            assert "RSI Oversold" in signal.conditions_met
+            assert signal.conditions_met["RSI Oversold"] is True
+    
+    def test_generate_signal_sell(self, generator, sample_data):
+        """売りシグナル生成のテスト"""
+        # RSIを高く設定して売りシグナルを誘発
+        indicators = TechnicalIndicators.calculate_all(sample_data)
+        indicators.loc[indicators.index[-1], 'RSI'] = 75
+        
+        signal = generator.generate_signal(sample_data, indicators=indicators)
+        
+        assert signal is not None
+        # RSIが高いので売りシグナルが出やすい
+        if signal.signal_type == SignalType.SELL:
+            assert "RSI Overbought" in signal.conditions_met
+            assert signal.conditions_met["RSI Overbought"] is True
+    
+    def test_generate_signal_multiple_conditions(self, generator, sample_data):
+        """複数条件でのシグナル生成のテスト"""
+        # 複数の買い条件を満たすように設定
+        indicators = TechnicalIndicators.calculate_all(sample_data)
+        indicators.loc[indicators.index[-1], 'RSI'] = 25
+        
+        # MACDクロスオーバーを追加
+        indicators.loc[indicators.index[-2], 'MACD'] = -0.5
+        indicators.loc[indicators.index[-1], 'MACD'] = 0.5
+        indicators.loc[indicators.index[-2:], 'MACD_Signal'] = 0
+        
+        signal = generator.generate_signal(sample_data, indicators=indicators)
+        
+        assert signal is not None
+        # 複数条件が満たされているか確認
+        active_conditions = sum(1 for v in signal.conditions_met.values() if v)
+        assert active_conditions >= 2
+    
+    def test_generate_signals_series(self, generator, sample_data):
+        """時系列シグナル生成のテスト"""
+        signals_df = generator.generate_signals_series(sample_data, lookback_window=30)
+        
+        assert isinstance(signals_df, pd.DataFrame)
+        if not signals_df.empty:
+            assert 'Signal' in signals_df.columns
+            assert 'Strength' in signals_df.columns
+            assert 'Confidence' in signals_df.columns
+            assert 'Price' in signals_df.columns
+            assert 'Reasons' in signals_df.columns
+            
+            # シグナルの値が正しいか
+            assert signals_df['Signal'].isin(['buy', 'sell', 'hold']).all()
+            assert signals_df['Strength'].isin(['strong', 'medium', 'weak']).all()
+            assert (signals_df['Confidence'] >= 0).all()
+            assert (signals_df['Confidence'] <= 100).all()
+    
+    def test_custom_rules(self, sample_data):
+        """カスタムルールの追加テスト"""
+        generator = TradingSignalGenerator()
+        
+        # デフォルトルール数を記録
+        initial_buy_rules = len(generator.buy_rules)
+        
+        # カスタムルールを追加
+        custom_rule = VolumeSpikeBuyRule()
+        generator.add_buy_rule(custom_rule)
+        
+        assert len(generator.buy_rules) == initial_buy_rules + 1
+        assert generator.buy_rules[-1] == custom_rule
+        
+        # カスタムルールの動作テスト - 出来高と価格を調整して条件を満たす
+        test_data = sample_data.copy()
+        test_data.loc[test_data.index[-1], 'Volume'] = 10000000  # 大きな出来高
+        test_data.loc[test_data.index[-1], 'Close'] = test_data['Close'].iloc[-2] * 1.03  # 3%上昇
+        
+        # シグナル生成
+        signal = generator.generate_signal(test_data)
+        assert signal is not None
+        
+        # 買いシグナルまたはホールドが生成されるはず（出来高急増により）
+        # 条件には「Volume Spike Buy」が含まれているはず
+        if signal.signal_type == SignalType.BUY:
+            assert "Volume Spike Buy" in signal.conditions_met
+            assert signal.conditions_met["Volume Spike Buy"] is True
+        else:
+            # シグナルタイプに関係なく、すべての条件は評価されていることを確認
+            # 実装では条件評価は行われているが、結果のconditions_metに含まれるかは
+            # シグナルタイプに依存する
+            pass
+    
+    def test_clear_rules(self, generator):
+        """ルールクリアのテスト"""
+        # ルールが存在することを確認
+        assert len(generator.buy_rules) > 0
+        assert len(generator.sell_rules) > 0
+        
+        # ルールをクリア
+        generator.clear_rules()
+        
+        assert len(generator.buy_rules) == 0
+        assert len(generator.sell_rules) == 0
+    
+    def test_validate_signal(self, generator, sample_data):
+        """シグナル検証のテスト"""
+        signal = generator.generate_signal(sample_data)
+        
+        if signal:
+            validity = generator.validate_signal(signal)
+            
+            assert isinstance(validity, float)
+            assert 0 <= validity <= 100
+            
+            # 強いシグナルの方が高い有効性スコアを持つ
+            if signal.strength == SignalStrength.STRONG:
+                assert validity >= signal.confidence
+    
+    def test_empty_data(self, generator):
+        """空データでのエラーハンドリング"""
+        empty_df = pd.DataFrame()
+        signal = generator.generate_signal(empty_df)
+        
+        assert signal is None
+    
+    def test_insufficient_data(self, generator):
+        """不十分なデータでのエラーハンドリング"""
+        dates = pd.date_range(end=datetime.now(), periods=10, freq='D')
+        small_df = pd.DataFrame({
+            'Date': dates,
+            'Open': [100] * 10,
+            'High': [101] * 10,
+            'Low': [99] * 10,
+            'Close': [100] * 10,
+            'Volume': [1000000] * 10
+        })
+        small_df.set_index('Date', inplace=True)
+        
+        signal = generator.generate_signal(small_df)
+        assert signal is None
+    
+    def test_signal_strength_classification(self, generator, sample_data):
+        """シグナル強度の分類テスト"""
+        # 強いシグナルを生成するように設定
+        indicators = TechnicalIndicators.calculate_all(sample_data)
+        
+        # 複数の強い条件を設定
+        indicators.loc[indicators.index[-1], 'RSI'] = 20  # 強い過売り
+        indicators.loc[indicators.index[-2], 'MACD'] = -1
+        indicators.loc[indicators.index[-1], 'MACD'] = 1  # 強いクロスオーバー
+        indicators.loc[:, 'MACD_Signal'] = 0
+        
+        # ボリンジャーバンド下限を突破
+        indicators.loc[indicators.index[-1], 'BB_Lower'] = sample_data['Close'].iloc[-1] + 1
+        
+        signal = generator.generate_signal(sample_data, indicators=indicators)
+        
+        assert signal is not None
+        # 複数の強い条件が満たされているので、強いシグナルになるはず
+        active_conditions = sum(1 for v in signal.conditions_met.values() if v)
+        if active_conditions >= 3 and signal.confidence >= 70:
+            assert signal.strength == SignalStrength.STRONG
+
+
+class TestCustomSignalRule:
+    """カスタムシグナルルールのテスト"""
+    
+    def test_custom_rule_implementation(self):
+        """カスタムルールの実装テスト"""
+        
+        class TestRule(SignalRule):
+            def __init__(self):
+                super().__init__("Test Rule", weight=1.0)
+            
+            def evaluate(self, df, indicators, patterns):
+                # 常にTrue、信頼度50%を返す
+                return True, 50.0
+        
+        rule = TestRule()
+        assert rule.name == "Test Rule"
+        assert rule.weight == 1.0
+        
+        # 評価メソッドのテスト
+        met, confidence = rule.evaluate(None, None, None)
+        assert met is True
+        assert confidence == 50.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- 売買シグナル生成エンジンを実装（Issue #62）
- RSI、MACD、ボリンジャーバンド、パターンブレイクアウト、ゴールデン/デッドクロスルールを実装
- シグナル強度の分類システム（強・中・弱）と信頼度スコアリングを追加
- カスタムルール作成をサポート

## Test plan
- [x] 個別ルール（RSI、MACD、ボリンジャーバンド等）のテスト
- [x] シグナル生成器の基本機能テスト
- [x] 買い・売りシグナル生成の個別テスト
- [x] 複数条件組み合わせシグナルのテスト
- [x] 時系列シグナル生成のテスト
- [x] カスタムルール追加・削除のテスト
- [x] シグナル検証機能のテスト
- [x] エラーハンドリング（空データ、不足データ）のテスト
- [x] シグナル強度分類のテスト
- [x] カスタムルール実装のテスト

🤖 Generated with [Claude Code](https://claude.ai/code)