### PR TITLE
fix-pyproject-test-group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,14 +58,15 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = [
+test = [
     # テスト関連
     "pytest>=7.4.0,<9.0",
     "pytest-cov>=4.1.0,<6.0",
     "pytest-mock>=3.10.0,<4.0",
     "pytest-xdist>=3.0.0,<4.0",
     "requests-mock>=1.12.0,<2.0",
-
+]
+dev = [
     # コード品質・フォーマット
     "black>=23.0.0,<25.0",
     "mypy>=1.4.0,<2.0",


### PR DESCRIPTION
## Summary
- pyproject.tomlにtestグループを追加してCI/CDエラーを修正
- test依存関係を別グループに分離
- dev依存関係からテスト関連を切り出し

## Test plan
- CI/CDワークフローの動作確認
- pip install .[test]が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)