### PR TITLE
feature/issue-122-bulk-stock-registration

### DIFF
--- a/scripts/test_bulk_registration.py
+++ b/scripts/test_bulk_registration.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+銘柄一括登録テストスクリプト
+"""
+
+import sys
+from pathlib import Path
+
+# プロジェクトルートをPATHに追加
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.day_trade.data.stock_master import StockMasterManager
+from src.day_trade.utils.logging_config import setup_logging
+
+# ロギング設定
+setup_logging()
+
+def test_registration():
+    """小規模テスト"""
+    stock_master = StockMasterManager()
+
+    # テスト用証券コード（有名な銘柄）
+    test_codes = ['7203', '9984', '6758']  # トヨタ、ソフトバンク、ソニー
+
+    print("=== 銘柄一括登録テスト ===")
+    print(f"テスト対象: {test_codes}")
+
+    # 一括取得・更新
+    result = stock_master.bulk_fetch_and_update_companies(
+        codes=test_codes,
+        batch_size=3,
+        delay=0.5
+    )
+
+    print("結果:")
+    print(f"  成功: {result['success']}")
+    print(f"  失敗: {result['failed']}")
+    print(f"  スキップ: {result['skipped']}")
+    print(f"  合計: {result['total']}")
+
+    # 登録された銘柄を確認
+    print("\n登録確認:")
+    for code in test_codes:
+        stock = stock_master.get_stock_by_code(code)
+        if stock:
+            print(f"  {code}: {stock.name} ({stock.market})")
+        else:
+            print(f"  {code}: 登録失敗")
+
+if __name__ == "__main__":
+    test_registration()


### PR DESCRIPTION
## Summary
Issue #122 - 銘柄を一括で追加する機能の実装と動作検証

- JPXから東証上場銘柄一覧（4168件）の自動ダウンロード機能
- 証券コード抽出とCSV形式での保存機能  
- 既存のStockMasterManager一括処理機能との統合
- 小規模テスト用スクリプトの追加

## 主な実装内容
- **jpx_stock_list_downloader.py**: JPXから銘柄一覧Excel取得・処理
- **bulk_stock_registration.py**: 一括登録処理（既存実装）
- **test_bulk_registration.py**: 小規模テスト用スクリプト（新規追加）

## 動作確認済み
- [x] JPXから4168件の銘柄データ正常取得
- [x] CSV形式での証券コード保存
- [x] 有名銘柄（トヨタ、ソフトバンク、ソニー）での登録テスト成功
- [x] 企業情報（名前、市場区分、セクター）の正確な取得・保存

## Test plan
- [x] JPXダウンロード機能テスト
- [x] 小規模銘柄登録テスト  
- [x] データベース登録確認

🤖 Generated with [Claude Code](https://claude.ai/code)