### PR TITLE
Fix: config_manager.pyのPydantic化に伴うSyntaxErrorを修正

### DIFF
--- a/src/day_trade/config/config_manager.py
+++ b/src/day_trade/config/config_manager.py
@@ -456,8 +456,8 @@ if __name__ == "__main__":
         logger.info("設定管理システムテスト完了", **config_info)
 
         # 銘柄の追加・更新・削除のテスト
-        logger.info("
---- 銘柄操作テスト ---")
+        logger.info("""
+--- 銘柄操作テスト ---""")
         initial_symbols = config_manager.get_symbol_codes()
         logger.info(f"初期銘柄数: {len(initial_symbols)}")
 


### PR DESCRIPTION
`src/day_trade/config/config_manager.py`の`__main__`ブロックにある`logger.info`内の複数行文字列リテラルが原因で発生していた`SyntaxError`を修正しました。

- 文字列リテラルを三重引用符`"""`で囲むことで、Pythonの構文として正しく解析されるようにしました。

Fixes #349 のCIエラー
