### PR TITLE
fix/github-actions-permissions

### DIFF
--- a/.github/workflows/advanced-triage.yml
+++ b/.github/workflows/advanced-triage.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 9 * * 1'    # 毎週月曜日9時にレポート生成
   workflow_dispatch:
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   advanced-triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 9 * * *'  # 毎日9時にトリアージ実行
   workflow_dispatch:  # 手動実行可能
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   triage-new-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/project-management.yml
+++ b/.github/workflows/project-management.yml
@@ -6,6 +6,11 @@ on:
     types: [opened, closed, merged, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   manage-project-board:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
GitHub Actionsワークフローに必要な権限を追加

## Changes
- **issue-triage.yml**: `issues:write`権限を追加してラベル自動付与を有効化
- **advanced-triage.yml**: `issues:write`権限を追加してSLA管理とコメント機能を有効化  
- **project-management.yml**: `issues:write`, `pull-requests:write`権限を追加してプロジェクトボード管理を有効化

## Issue
イシュー #403 のテスト時にGitHub Actionsで権限エラー（403 Forbidden）が発生：
- `Resource not accessible by integration`
- `GITHUB_TOKEN`にissues操作権限が不足

## Test plan
- [x] YAML構文の妥当性確認
- [ ] イシュー作成時の自動ラベル付けテスト
- [ ] 自動コメント機能テスト
- [ ] プロジェクトボード自動追加テスト

🤖 Generated with [Claude Code](https://claude.ai/code)