### PR TITLE
fix: Issue #445 - Remove unnecessary notification parameters

### DIFF
--- a/simple_notification_test.py
+++ b/simple_notification_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Issue #445: 不要な通知パラメータ削除の簡単なテスト
+"""
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+
+def test_notification_channels():
+    """通知チャンネルの削除確認"""
+    print("Issue #445: 不要な通知パラメータ削除テスト")
+    print("=" * 50)
+
+    try:
+        # alert_engine.pyのNotificationChannelをテスト
+        from day_trade.monitoring.alert_engine import NotificationChannel
+
+        print("\n✓ alert_engine.py - NotificationChannel:")
+        channels = [member.value for member in NotificationChannel]
+        print(f"  現在のチャンネル: {channels}")
+
+        # 必要なチャンネルが存在することを確認
+        expected = ["email", "slack", "webhook"]
+        for channel in expected:
+            if channel in channels:
+                print(f"  ✓ {channel} - 保持")
+            else:
+                print(f"  ✗ {channel} - 見つかりません")
+
+        # 削除されたチャンネルが存在しないことを確認
+        removed = ["sms", "discord"]
+        for channel in removed:
+            if channel not in channels:
+                print(f"  ✓ {channel} - 正しく削除されました")
+            else:
+                print(f"  ✗ {channel} - まだ存在しています")
+
+    except Exception as e:
+        print(f"✗ alert_engine.pyのテスト失敗: {e}")
+
+    try:
+        # notification_system.pyの基本動作テスト
+        from day_trade.monitoring.notification_system import NotificationSystem
+
+        print("\n✓ notification_system.py - インポートテスト:")
+        system = NotificationSystem()
+        print("  ✓ NotificationSystemの初期化成功")
+        print(f"  ✓ テンプレート数: {len(system.templates)}")
+        print(f"  ✓ 通知履歴: {len(system.notification_history)}")
+
+    except Exception as e:
+        print(f"✗ notification_system.pyのテスト失敗: {e}")
+
+    print("\n" + "=" * 50)
+    print("削除完了サマリー:")
+    print("■ 削除された通知チャンネル:")
+    print("  - SMS通知（未実装）")
+    print("  - Discord通知（機能重複）")
+    print("■ 保持された通知チャンネル:")
+    print("  - Email通知（重要）")
+    print("  - Slack通知（チーム通知）")
+    print("  - Webhook通知（外部統合）")
+    print("=" * 50)
+
+if __name__ == "__main__":
+    test_notification_channels()

--- a/src/day_trade/monitoring/alert_engine.py
+++ b/src/day_trade/monitoring/alert_engine.py
@@ -39,8 +39,6 @@ class NotificationChannel(Enum):
     EMAIL = "email"
     SLACK = "slack"
     WEBHOOK = "webhook"
-    SMS = "sms"
-    DISCORD = "discord"
 
 
 @dataclass

--- a/src/day_trade/monitoring/notification_system.py
+++ b/src/day_trade/monitoring/notification_system.py
@@ -7,8 +7,6 @@ Features:
 - Slack通知
 - Email通知
 - Webhook通知
-- Discord通知
-- SMS通知（将来拡張）
 - テンプレート管理
 - 通知履歴
 """
@@ -229,8 +227,6 @@ class NotificationSystem:
                 await self._send_email_notification(alert)
             elif channel == NotificationChannel.WEBHOOK:
                 await self._send_webhook_notification(alert)
-            elif channel == NotificationChannel.DISCORD:
-                await self._send_discord_notification(alert)
             else:
                 logger.warning(f"未実装の通知チャネル: {channel.value}")
 
@@ -363,47 +359,6 @@ class NotificationSystem:
                 if response.status >= 400:
                     raise Exception(f"Webhook エラー: {response.status}")
 
-    async def _send_discord_notification(self, alert: Alert):
-        """Discord通知送信"""
-
-        config = self.configs[NotificationChannel.DISCORD]
-        webhook_url = config.settings.get("webhook_url")
-
-        if not webhook_url:
-            raise ValueError("Discord webhook URL未設定")
-
-        # テンプレート取得・レンダリング（Slackと同じ形式を使用）
-        template = self._get_template(NotificationChannel.SLACK, alert.severity)
-        title = Template(template.title_template).render(alert=alert)
-        body = Template(template.body_template).render(alert=alert)
-
-        # Discord色コード変換
-        color_map = {
-            "#36a64f": 3580735,  # 緑
-            "#ffa500": 16753920,  # オレンジ
-            "#ff0000": 16711680,  # 赤
-            "#8B0000": 9109504,  # ダークレッド
-        }
-
-        # Discord Webhook ペイロード作成
-        payload = {
-            "username": "Day Trade Monitor",
-            "embeds": [
-                {
-                    "title": title,
-                    "description": body[:2000],  # Discord制限
-                    "color": color_map.get(template.color, 3580735),
-                    "timestamp": alert.start_time.isoformat(),
-                    "footer": {"text": "Day Trade Monitoring System"},
-                }
-            ],
-        }
-
-        # HTTP POST送信
-        async with aiohttp.ClientSession() as session:
-            async with session.post(webhook_url, json=payload) as response:
-                if response.status != 200:
-                    raise Exception(f"Discord API エラー: {response.status}")
 
     def _get_template(
         self, channel: NotificationChannel, severity: AlertSeverity

--- a/src/day_trade/realtime/alert_system.py
+++ b/src/day_trade/realtime/alert_system.py
@@ -54,7 +54,6 @@ class AlertConfig:
     enable_email: bool = True
     enable_console: bool = True
     enable_webhook: bool = False
-    enable_sms: bool = False
 
     # Email設定
     smtp_server: str = "smtp.gmail.com"

--- a/src/day_trade/risk_management/config/unified_config.py
+++ b/src/day_trade/risk_management/config/unified_config.py
@@ -106,7 +106,7 @@ class AlertConfig:
     # 通知チャネル設定
     email_config: Dict[str, str] = field(default_factory=dict)
     slack_config: Dict[str, str] = field(default_factory=dict)
-    sms_config: Dict[str, str] = field(default_factory=dict)
+    webhook_config: Dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_env(cls) -> "AlertConfig":

--- a/src/day_trade/risk_management/factories/alert_factory.py
+++ b/src/day_trade/risk_management/factories/alert_factory.py
@@ -23,13 +23,7 @@ class NotificationChannelType(Enum):
 
     EMAIL = "email"
     SLACK = "slack"
-    DISCORD = "discord"
-    TEAMS = "teams"
-    SMS = "sms"
     WEBHOOK = "webhook"
-    TELEGRAM = "telegram"
-    PUSH_NOTIFICATION = "push_notification"
-    PLUGIN = "plugin"
 
 
 class AlertSeverity(Enum):
@@ -104,18 +98,6 @@ class AlertChannelFactory:
                 },
             )
 
-            # Discord通知
-            self.register_channel(
-                NotificationChannelType.DISCORD,
-                "src.day_trade.risk_management.notifications.discord_channel",
-                "DiscordNotificationChannel",
-                {
-                    "webhook_url": {"type": str, "required": True},
-                    "username": {"type": str, "default": "Risk Alert"},
-                    "avatar_url": {"type": str, "required": False},
-                    "color": {"type": int, "default": 16711680},  # Red
-                },
-            )
 
             # Webhook通知
             self.register_channel(
@@ -139,35 +121,6 @@ class AlertChannelFactory:
                 },
             )
 
-            # SMS通知
-            self.register_channel(
-                NotificationChannelType.SMS,
-                "src.day_trade.risk_management.notifications.sms_channel",
-                "SMSNotificationChannel",
-                {
-                    "provider": {
-                        "type": str,
-                        "default": "twilio",
-                    },  # "twilio", "aws_sns"
-                    "api_key": {"type": str, "required": True},
-                    "api_secret": {"type": str, "required": True},
-                    "from_number": {"type": str, "required": True},
-                    "region": {"type": str, "default": "us-east-1"},
-                },
-            )
-
-            # Telegram通知
-            self.register_channel(
-                NotificationChannelType.TELEGRAM,
-                "src.day_trade.risk_management.notifications.telegram_channel",
-                "TelegramNotificationChannel",
-                {
-                    "bot_token": {"type": str, "required": True},
-                    "default_chat_id": {"type": str, "required": True},
-                    "parse_mode": {"type": str, "default": "HTML"},
-                    "disable_notification": {"type": bool, "default": False},
-                },
-            )
 
         except Exception as e:
             import logging

--- a/src/day_trade/risk_management/interfaces/alert_interfaces.py
+++ b/src/day_trade/risk_management/interfaces/alert_interfaces.py
@@ -3,7 +3,7 @@
 Alert Management Interfaces
 アラート管理インターフェース
 
-Slack、Email、SMS等の各種通知チャネルに対応した抽象インターフェース
+Slack、Email、Webhook等の各種通知チャネルに対応した抽象インターフェース
 """
 
 from abc import ABC, abstractmethod
@@ -37,10 +37,7 @@ class NotificationChannel(Enum):
 
     SLACK = "slack"
     EMAIL = "email"
-    SMS = "sms"
     WEBHOOK = "webhook"
-    DASHBOARD = "dashboard"
-    PUSH_NOTIFICATION = "push"
 
 
 @dataclass

--- a/test_notification_cleanup.py
+++ b/test_notification_cleanup.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Issue #445: 不要な通知パラメータ削除のテスト
+テストケース：削除された通知チャネルが正しく除外されていることを確認
+"""
+
+import unittest
+from enum import Enum
+
+try:
+    from src.day_trade.monitoring.alert_engine import NotificationChannel as AlertNotificationChannel
+    from src.day_trade.risk_management.factories.alert_factory import NotificationChannelType
+    from src.day_trade.risk_management.interfaces.alert_interfaces import NotificationChannel as InterfaceNotificationChannel
+except ImportError as e:
+    print(f"Import error: {e}")
+    exit(1)
+
+
+class TestNotificationChannelCleanup(unittest.TestCase):
+    """通知チャンネル削除テスト"""
+
+    def test_alert_engine_notification_channels(self):
+        """alert_engine.pyの通知チャンネル確認"""
+        # 必要なチャンネルのみ残っていることを確認
+        expected_channels = {"EMAIL", "SLACK", "WEBHOOK"}
+        actual_channels = {member.name for member in AlertNotificationChannel}
+
+        self.assertEqual(actual_channels, expected_channels)
+
+        # 不要なチャンネルが削除されていることを確認
+        removed_channels = {"SMS", "DISCORD"}
+        for channel in removed_channels:
+            self.assertNotIn(channel, actual_channels, f"{channel} should be removed")
+
+    def test_alert_factory_notification_channel_types(self):
+        """alert_factory.pyの通知チャンネルタイプ確認"""
+        # 必要なチャンネルのみ残っていることを確認
+        expected_types = {"EMAIL", "SLACK", "WEBHOOK"}
+        actual_types = {member.name for member in NotificationChannelType}
+
+        self.assertEqual(actual_types, expected_types)
+
+        # 不要なチャンネルが削除されていることを確認
+        removed_types = {"SMS", "DISCORD", "TEAMS", "TELEGRAM", "PUSH_NOTIFICATION", "PLUGIN"}
+        for channel_type in removed_types:
+            self.assertNotIn(channel_type, actual_types, f"{channel_type} should be removed")
+
+    def test_interface_notification_channels(self):
+        """interfaces.pyの通知チャンネル確認"""
+        # 必要なチャンネルのみ残っていることを確認
+        expected_channels = {"EMAIL", "SLACK", "WEBHOOK"}
+        actual_channels = {member.name for member in InterfaceNotificationChannel}
+
+        self.assertEqual(actual_channels, expected_channels)
+
+        # 不要なチャンネルが削除されていることを確認
+        removed_channels = {"SMS", "DASHBOARD", "PUSH_NOTIFICATION"}
+        for channel in removed_channels:
+            self.assertNotIn(channel, actual_channels, f"{channel} should be removed")
+
+    def test_notification_channel_values(self):
+        """通知チャンネルの値が正しいことを確認"""
+        # alert_engine
+        self.assertEqual(AlertNotificationChannel.EMAIL.value, "email")
+        self.assertEqual(AlertNotificationChannel.SLACK.value, "slack")
+        self.assertEqual(AlertNotificationChannel.WEBHOOK.value, "webhook")
+
+        # alert_factory
+        self.assertEqual(NotificationChannelType.EMAIL.value, "email")
+        self.assertEqual(NotificationChannelType.SLACK.value, "slack")
+        self.assertEqual(NotificationChannelType.WEBHOOK.value, "webhook")
+
+        # interfaces
+        self.assertEqual(InterfaceNotificationChannel.EMAIL.value, "email")
+        self.assertEqual(InterfaceNotificationChannel.SLACK.value, "slack")
+        self.assertEqual(InterfaceNotificationChannel.WEBHOOK.value, "webhook")
+
+
+class TestNotificationSystemIntegration(unittest.TestCase):
+    """通知システム統合テスト"""
+
+    def test_notification_system_import(self):
+        """通知システムの正常インポート確認"""
+        try:
+            from src.day_trade.monitoring.notification_system import NotificationSystem
+            system = NotificationSystem()
+            self.assertIsInstance(system, NotificationSystem)
+        except Exception as e:
+            self.fail(f"NotificationSystem import failed: {e}")
+
+    def test_alert_engine_import(self):
+        """アラートエンジンの正常インポート確認"""
+        try:
+            from src.day_trade.monitoring.alert_engine import IntelligentAlertEngine
+            engine = IntelligentAlertEngine()
+            self.assertIsInstance(engine, IntelligentAlertEngine)
+        except Exception as e:
+            self.fail(f"IntelligentAlertEngine import failed: {e}")
+
+    def test_alert_factory_import(self):
+        """アラートファクトリーの正常インポート確認"""
+        try:
+            from src.day_trade.risk_management.factories.alert_factory import AlertChannelFactory
+            factory = AlertChannelFactory()
+            self.assertIsInstance(factory, AlertChannelFactory)
+        except Exception as e:
+            self.fail(f"AlertChannelFactory import failed: {e}")
+
+
+def print_cleanup_summary():
+    """削除内容のサマリー表示"""
+    print("\n" + "="*60)
+    print("Issue #445: 不要な通知パラメータ削除完了サマリー")
+    print("="*60)
+    print("\n■ 削除された通知チャンネル:")
+    print("  - SMS通知（未実装で不要）")
+    print("  - Discord通知（SlackやEmailと機能重複）")
+    print("  - Teams通知（使用されていない）")
+    print("  - Telegram通知（使用されていない）")
+    print("  - Push通知（使用されていない）")
+    print("  - Dashboard通知（使用されていない）")
+
+    print("\n■ 保持された通知チャンネル:")
+    print("  - Email通知（重要な通知手段）")
+    print("  - Slack通知（チーム通知に必要）")
+    print("  - Webhook通知（外部統合に必要）")
+
+    print("\n■ 変更されたファイル:")
+    files = [
+        "src/day_trade/monitoring/alert_engine.py",
+        "src/day_trade/monitoring/notification_system.py",
+        "src/day_trade/risk_management/factories/alert_factory.py",
+        "src/day_trade/risk_management/config/unified_config.py",
+        "src/day_trade/risk_management/interfaces/alert_interfaces.py",
+        "src/day_trade/realtime/alert_system.py"
+    ]
+    for file in files:
+        print(f"  - {file}")
+
+    print("\n■ 効果:")
+    print("  - 不要な通知設定パラメータを削除")
+    print("  - 設定ファイルの簡素化")
+    print("  - メンテナンス性の向上")
+    print("  - 実際に使用される機能への集中")
+    print("="*60)
+
+
+if __name__ == "__main__":
+    print_cleanup_summary()
+    print("\n通知チャンネル削除のテストを実行します...")
+    unittest.main()


### PR DESCRIPTION
## 概要
Issue #445「不要な通知パラメータは削除」に対応し、システムで使用されていない不要な通知チャンネルを削除してシステムを簡素化しました。

## 削除した通知チャンネル
- **SMS通知** - 未実装で実際には使用されていない
- **Discord通知** - SlackやEmailと機能が重複している
- **Teams通知** - 使用されていない
- **Telegram通知** - 使用されていない  
- **Push通知** - 使用されていない
- **Dashboard通知** - 使用されていない

## 保持した通知チャンネル
- **Email通知** - 重要な通知手段として必要
- **Slack通知** - チーム通知に必要
- **Webhook通知** - 外部システム統合に必要

## 変更ファイル
- `src/day_trade/monitoring/alert_engine.py`
- `src/day_trade/monitoring/notification_system.py`
- `src/day_trade/risk_management/factories/alert_factory.py`
- `src/day_trade/risk_management/config/unified_config.py`
- `src/day_trade/risk_management/interfaces/alert_interfaces.py`
- `src/day_trade/realtime/alert_system.py`

## 効果
- 不要な設定パラメータの削除
- 設定ファイルの簡素化
- メンテナンス性の向上
- 実際に使用される機能への集中

## テスト
- 構文チェック完了
- ruff品質チェック完了
- 基本的なインポート・初期化テスト完了

🤖 Generated with [Claude Code](https://claude.ai/code)