### PR TITLE
hotfix: Fix syntax error in model_performance_monitor.py

### DIFF
--- a/model_performance_monitor.py
+++ b/model_performance_monitor.py
@@ -1,10 +1,7 @@
 import numpy as np
 from collections import deque
-<<<<<<< HEAD
 import json
 from pathlib import Path
-=======
->>>>>>> 6d241116c5f580dca22013359f59b2fa52caa6e2
 
 class ModelPerformanceMonitor:
     """


### PR DESCRIPTION
## 🚨 緊急修正

### 問題
マージ後にmodel_performance_monitor.pyでSyntaxErrorが発生していました：
```
SyntaxError: invalid decimal literal
```

### 原因
マージコンフリクトマーカーが残っていました：
```python
<<<<<<< HEAD
import json
from pathlib import Path
=======
>>>>>>> 6d241116c5f580dca22013359f59b2fa52caa6e2
```

### 修正内容
- [x] マージコンフリクトマーカーを削除
- [x] 正しいimport文を保持
- [x] 動作確認完了

### 確認結果
```bash
python daytrade.py --help
# エラーなく正常に実行
```

🤖 Generated with [Claude Code](https://claude.ai/code)